### PR TITLE
Add getIn to RecordInstance

### DIFF
--- a/dist/immutable.js.flow
+++ b/dist/immutable.js.flow
@@ -1175,6 +1175,7 @@ declare class RecordInstance<T: Object> {
   clear(): this & T;
 
   setIn(keyPath: Iterable<any>, value: any): this & T;
+  getIn<K: $Keys<T>>(searchKeyPath: Iterable<any>, notSetValue?: any): $ElementType<T, K>;	  
   updateIn(keyPath: Iterable<any>, updater: (value: any) => any): this & T;
   mergeIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;
   mergeDeepIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1175,6 +1175,7 @@ declare class RecordInstance<T: Object> {
   clear(): this & T;
 
   setIn(keyPath: Iterable<any>, value: any): this & T;
+  getIn<K: $Keys<T>>(searchKeyPath: Iterable<any>, notSetValue?: any): $ElementType<T, K>;	  
   updateIn(keyPath: Iterable<any>, updater: (value: any) => any): this & T;
   mergeIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;
   mergeDeepIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;


### PR DESCRIPTION
Just adds what seems to be the correct type for `getIn` to `RecordInstance`. Passes my typechecks that were failing with `getIn` missing from the instance.